### PR TITLE
Fix: Correct report visibility for Supervisor role

### DIFF
--- a/index.html
+++ b/index.html
@@ -7889,9 +7889,12 @@ const loadReceivedReports = () => {
     // Snapshot listener
     onSnapshot(baseQuery, (snapshot) => {
     let relevantDocs = [];
-    if (['supervisore', 'adm'].includes(userRole)) {
-        // Supervisore e Admin vedono TUTTE le segnalazioni, senza filtri per destinatario.
+    if (userRole === 'adm') {
+        // L'Admin è l'unico che vede TUTTE le segnalazioni.
         relevantDocs = snapshot.docs;
+    } else if (userRole === 'supervisore') {
+        // IL SUPERVISORE (come un consigliere) VEDE SOLO LE SEGNALAZIONI PER I CONSIGLIERI.
+        relevantDocs = snapshot.docs.filter(doc => doc.data().recipientType === 'consigliere');
     } else if (isAdmin) {
         // L'amministratore vede ticket a lui assegnati e quelli per lo sviluppatore.
         relevantDocs = snapshot.docs.filter(doc => {


### PR DESCRIPTION
The Supervisor role was incorrectly configured to view all reports. This change modifies the filtering logic in the `loadReceivedReports` function to align the Supervisor's visibility with that of a Councilor.

Supervisors will now only see reports where the `recipientType` is 'consigliere'. The global visibility for the 'adm' role remains unchanged.