### PR TITLE
feat: Implement notification badge for urgent reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -2170,13 +2170,14 @@ let selectedCommunicationFiles = []; // Array per i file della comunicazione
             // 1. Solleciti - MODIFICATO per includere 'consigliere'
             if (['supervisore', 'adm', 'amministratore', 'consigliere'].includes(userRole)) {
                 menuItemsHtml.push(`
-                    <div onclick="navigateTo('segnalazioni_urgenti')" class="dashboard-item">
-                        <div class="dashboard-card" style="border: 2px solid var(--danger);">
-                            <svg fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>
-                        </div>
-                        <p>Solleciti</p>
-                    </div>
-                `);
+    <div onclick="navigateTo('segnalazioni_urgenti')" class="dashboard-item">
+        <div class="dashboard-card" style="border: 2px solid var(--danger); position: relative;">
+            <span id="solleciti-notification-badge" class="notification-badge hidden" style="top: 8px; right: 8px;"></span>
+            <svg fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>
+        </div>
+        <p>Solleciti</p>
+    </div>
+`);
             }
 
             // 2. Segnalazioni ricevute
@@ -4315,6 +4316,7 @@ ${formRecipientField}
                 checkForNewCommunications();
                 checkForNewPolls();
                 checkForNewReports();
+                checkForUrgentReports();
             }
         };
 
@@ -7978,6 +7980,19 @@ const loadReceivedReports = () => {
         `;
 
         const loadUrgentReports = () => {
+    const q = query(collection(db, "reports"), where("isUrgent", "==", true), orderBy("lastReminderAt", "desc"), limit(1));
+    getDocs(q).then(snapshot => {
+        if (!snapshot.empty) {
+            const latestReminderTimestamp = snapshot.docs[0].data().lastReminderAt.toMillis();
+            localStorage.setItem(`lastSeenUrgentReport_${currentUser.uid}`, latestReminderTimestamp);
+            updateUrgentNotificationUI(0);
+        } else {
+            // Se non ci sono report urgenti, imposta l'ora corrente come vista
+            localStorage.setItem(`lastSeenUrgentReport_${currentUser.uid}`, Date.now());
+            updateUrgentNotificationUI(0);
+        }
+    });
+
             const mainContainer = document.getElementById('reports-main-container');
             if (!mainContainer) return;
 
@@ -9172,6 +9187,50 @@ const loadReceivedReports = () => {
             });
         };
 
+const updateUrgentNotificationUI = (count) => {
+    const badge = document.getElementById('solleciti-notification-badge');
+    if (badge) {
+        const shouldBeHidden = count === 0;
+        badge.classList.toggle("hidden", shouldBeHidden);
+        if (!shouldBeHidden) {
+            badge.textContent = count > 9 ? '9+' : count;
+        }
+    }
+};
+
+let urgentReportsListener = null;
+const checkForUrgentReports = () => {
+    // Questa funzione è solo per i ruoli che possono vedere i solleciti.
+    if (!currentUser || !['supervisore', 'adm', 'amministratore', 'consigliere'].includes(userProfile?.tipoUtente)) {
+        updateUrgentNotificationUI(0);
+        return;
+    }
+
+    urgentReportsListener && urgentReportsListener();
+
+    const lastSeen = parseInt(localStorage.getItem(`lastSeenUrgentReport_${currentUser.uid}`), 10) || 0;
+    const lastSeenDate = new Date(lastSeen);
+
+    // Contiamo le segnalazioni urgenti il cui sollecito è stato inviato DOPO l'ultima visita alla pagina dei solleciti.
+    const q = query(
+        collection(db, "reports"),
+        where("isUrgent", "==", true),
+        where("lastReminderAt", ">", lastSeenDate)
+    );
+
+    urgentReportsListener = onSnapshot(q, snapshot => {
+        // L'admin e il supervisore vedono tutti i solleciti. L'amministratore e i consiglieri solo quelli a loro destinati.
+        const relevantDocs = snapshot.docs.filter(doc => {
+            const report = doc.data();
+            if (['adm', 'supervisore'].includes(userProfile.tipoUtente)) {
+                return true;
+            }
+            return report.recipientType === userProfile.tipoUtente;
+        });
+        updateUrgentNotificationUI(relevantDocs.length);
+    });
+};
+
         window.navigateTo = navigateTo;
         window.navigateBack = navigateBack;
         window.logout = logout;
@@ -9301,6 +9360,7 @@ const loadReceivedReports = () => {
                     await renderCurrentPage();
                 }
 
+    checkForUrgentReports();
             } else {
                 // L'utente non è loggato o ha appena fatto logout
                 if (communicationsListener) {


### PR DESCRIPTION
This commit introduces a notification badge system for the "Solleciti" (Urgent Reports) section.

Key changes include:
- UI Update: Added a notification badge to the "Solleciti" button in `renderSegnalazioniMenu`.
- Counting Logic: Implemented `updateUrgentNotificationUI` and `checkForUrgentReports` functions to fetch the count of new urgent reports from Firestore based on the last visit timestamp stored in localStorage.
- Integration:
  - The notification counter is reset when the user visits the urgent reports page (`loadUrgentReports`).
  - The notification check is triggered on every page navigation (`renderCurrentPage`) and upon user login (`onAuthStateChanged`) to ensure the badge is always up-to-date.