### PR TITLE
feat: Display interest type badge in report cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -7622,6 +7622,7 @@ const recipient = document.getElementById("report-recipient").value;
                         <div class="subtitle" style="display:flex; gap:0.5rem; flex-wrap:wrap; margin-top:0.25rem;">
                             <span class="badge ${getPriorityColor(report.priority)}">${report.priority}</span>
                             <span class="badge ${getStatusColor(report.status)}">${report.status}</span>
+                            ${report.interestType ? `<span class="badge status-aperta">${report.interestType === 'condominiale' ? 'Condominiale' : 'Personale'}</span>` : ''}
                             <span class="badge status-aperta">Dest: ${report.recipientType.charAt(0).toUpperCase() + report.recipientType.slice(1)}</span>
                         </div>
                     </div>


### PR DESCRIPTION
This change modifies the `renderReportCardHTML` function to display a badge indicating whether a report is of 'personale' (personal) or 'condominiale' (condominial) interest.

The badge is only rendered if the `interestType` field exists in the report data and is styled consistently with other badges in the UI.